### PR TITLE
Add @tsconfig/strictest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
 	"homepage": "https://github.com/ldrick/trade-indicators",
 	"license": "MIT",
 	"author": {
-		"name": "Ricky Lippmann",
-		"email": "ricky.lippmann@gmail.com"
+		"name": "Ricky Lippmann"
 	},
 	"repository": {
 		"type": "git",
@@ -102,6 +101,7 @@
 		"@tsconfig/node-lts": "^24.0.0",
 		"@tsconfig/node-ts": "^23.6.4",
 		"@tsconfig/recommended": "^1.0.13",
+		"@tsconfig/strictest": "^2.0.8",
 		"@types/big.js": "^7.0.0",
 		"@types/node": "^26.1.0",
 		"@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.13
         version: 1.0.13
+      '@tsconfig/strictest':
+        specifier: ^2.0.8
+        version: 2.0.8
       '@types/big.js':
         specifier: ^7.0.0
         version: 7.0.0
@@ -489,6 +492,9 @@ packages:
 
   '@tsconfig/recommended@1.0.13':
     resolution: {integrity: sha512-sySRuBfMKyKO/j2ZAhR8kSembhjuPEV4Ra3AHtmWLq51+iGaudr45crPSzNC5b7/Ctrh9dfUpBuTlYrH6rM58Q==}
+
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -2313,6 +2319,8 @@ snapshots:
   '@tsconfig/node-ts@23.6.4': {}
 
   '@tsconfig/recommended@1.0.13': {}
+
+  '@tsconfig/strictest@2.0.8': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/src/averages/dema.ts
+++ b/src/averages/dema.ts
@@ -1,6 +1,13 @@
 import { Big } from 'big.js';
-import { apply as AP, either as E, function as F, readonlyNonEmptyArray as RNEA } from 'fp-ts';
+import {
+	apply as AP,
+	either as E,
+	function as F,
+	readonlyArray as RA,
+	readonlyNonEmptyArray as RNEA,
+} from 'fp-ts';
 
+import { UnequalArraySizesError } from '../errors/UnequalArraySizesError.js';
 import * as array from '../utils/array.js';
 import * as number_ from '../utils/number.js';
 import { emaC } from './ema.js';
@@ -9,10 +16,17 @@ const calculate = (
 	one: RNEA.ReadonlyNonEmptyArray<Big>,
 	two: RNEA.ReadonlyNonEmptyArray<Big>,
 	period: number,
-): RNEA.ReadonlyNonEmptyArray<number> =>
+): E.Either<Error, RNEA.ReadonlyNonEmptyArray<number>> =>
 	F.pipe(
 		two,
-		RNEA.mapWithIndex((index, value) => one[index + period - 1].mul(2).sub(value).toNumber()),
+		RNEA.traverseWithIndex(E.Applicative)((index, value) =>
+			F.pipe(
+				RA.lookup(index + period - 1)(one),
+				// v8 ignore next -- `one` and `two` are both derived from the same EMA chain, so their lengths are always in sync
+				E.fromOption(() => new UnequalArraySizesError()),
+				E.map((oneValue) => oneValue.mul(2).sub(value).toNumber()),
+			),
+		),
 	);
 
 /**
@@ -33,5 +47,5 @@ export const dema = (
 		E.bind('valuesB', ({ valuesV }) => array.toBig(valuesV)),
 		E.bind('emaOne', ({ periodV, valuesB }) => emaC(valuesB, periodV)),
 		E.bind('emaTwo', ({ emaOne, periodV }) => emaC(emaOne, periodV)),
-		E.map(({ emaOne, emaTwo, periodV }) => calculate(emaOne, emaTwo, periodV)),
+		E.chain(({ emaOne, emaTwo, periodV }) => calculate(emaOne, emaTwo, periodV)),
 	);

--- a/src/averages/macd.ts
+++ b/src/averages/macd.ts
@@ -8,6 +8,7 @@ import {
 } from 'fp-ts';
 
 import { PeriodSizeMissmatchError } from '../errors/PeriodSizeMissmatchError.js';
+import { UnequalArraySizesError } from '../errors/UnequalArraySizesError.js';
 import * as array from '../utils/array.js';
 import * as number_ from '../utils/number.js';
 import { emaC } from './ema.js';
@@ -25,13 +26,17 @@ const validatePeriodSizes = (slowPeriod: number, fastPeriod: number): E.Either<E
 const calculate = (
 	fast: RNEA.ReadonlyNonEmptyArray<Big>,
 	slow: RNEA.ReadonlyNonEmptyArray<Big>,
-): RNEA.ReadonlyNonEmptyArray<Big> =>
+): E.Either<Error, RNEA.ReadonlyNonEmptyArray<Big>> =>
 	F.pipe(
 		slow,
-		RNEA.mapWithIndex((index, value) => {
-			const shortened = RA.takeRight(slow.length)(fast);
-			return shortened[index].sub(value);
-		}),
+		RNEA.traverseWithIndex(E.Applicative)((index, value) =>
+			F.pipe(
+				RA.lookup(fast.length - slow.length + index)(fast),
+				// v8 ignore next -- `fast` is always at least as long as `slow`, guaranteed by validatePeriodSizes
+				E.fromOption(() => new UnequalArraySizesError()),
+				E.map((fastValue) => fastValue.sub(value)),
+			),
+		),
 	);
 
 /**
@@ -60,7 +65,7 @@ export const macd = (
 		E.bind('valuesB', ({ valuesV }) => array.toBig(valuesV)),
 		E.bind('emaSlow', ({ slowPeriodV, valuesB }) => emaC(valuesB, slowPeriodV)),
 		E.bind('emaFast', ({ fastPeriodV, valuesB }) => emaC(valuesB, fastPeriodV)),
-		E.bind('macdResult', ({ emaFast, emaSlow }) => E.right(calculate(emaFast, emaSlow))),
+		E.bind('macdResult', ({ emaFast, emaSlow }) => calculate(emaFast, emaSlow)),
 		E.bind('signal', ({ macdResult, signalPeriodV }) => emaC(macdResult, signalPeriodV)),
 		E.map(({ macdResult, signal }) => ({
 			macd: array.toNumber(macdResult),

--- a/src/averages/tema.ts
+++ b/src/averages/tema.ts
@@ -1,6 +1,14 @@
 import { Big } from 'big.js';
-import { apply as AP, either as E, function as F, readonlyNonEmptyArray as RNEA } from 'fp-ts';
+import {
+	apply as AP,
+	either as E,
+	function as F,
+	option as O,
+	readonlyArray as RA,
+	readonlyNonEmptyArray as RNEA,
+} from 'fp-ts';
 
+import { UnequalArraySizesError } from '../errors/UnequalArraySizesError.js';
 import * as array from '../utils/array.js';
 import * as number_ from '../utils/number.js';
 import { emaC } from './ema.js';
@@ -10,15 +18,19 @@ const calculate = (
 	two: RNEA.ReadonlyNonEmptyArray<Big>,
 	three: RNEA.ReadonlyNonEmptyArray<Big>,
 	period: number,
-): RNEA.ReadonlyNonEmptyArray<number> =>
+): E.Either<Error, RNEA.ReadonlyNonEmptyArray<number>> =>
 	F.pipe(
 		three,
-		RNEA.mapWithIndex((index, value) =>
-			one[index + 2 * (period - 1)]
-				.mul(3)
-				.sub(two[index + period - 1].mul(3))
-				.add(value)
-				.toNumber(),
+		RNEA.traverseWithIndex(E.Applicative)((index, value) =>
+			F.pipe(
+				O.bindTo('oneValue')(RA.lookup(index + 2 * (period - 1))(one)),
+				O.bind('twoValue', () => RA.lookup(index + period - 1)(two)),
+				O.map(({ oneValue, twoValue }) =>
+					oneValue.mul(3).sub(twoValue.mul(3)).add(value).toNumber(),
+				),
+				// v8 ignore next -- `one`, `two` and `three` are all derived from the same EMA chain, so their lengths are always in sync
+				E.fromOption(() => new UnequalArraySizesError()),
+			),
 		),
 	);
 
@@ -42,7 +54,7 @@ export const tema = (
 		E.bind('emaOne', ({ periodV, valuesB }) => emaC(valuesB, periodV)),
 		E.bind('emaTwo', ({ emaOne, periodV }) => emaC(emaOne, periodV)),
 		E.bind('emaThree', ({ emaTwo, periodV }) => emaC(emaTwo, periodV)),
-		E.map(({ emaOne, emaThree, emaTwo, periodV }) =>
+		E.chain(({ emaOne, emaThree, emaTwo, periodV }) =>
 			calculate(emaOne, emaTwo, emaThree, periodV),
 		),
 	);

--- a/src/movements/adx.ts
+++ b/src/movements/adx.ts
@@ -1,7 +1,15 @@
 import { Big } from 'big.js';
-import { apply as AP, either as E, function as F, readonlyNonEmptyArray as RNEA } from 'fp-ts';
+import {
+	apply as AP,
+	either as E,
+	function as F,
+	option as O,
+	readonlyArray as RA,
+	readonlyNonEmptyArray as RNEA,
+} from 'fp-ts';
 
 import { smmaC } from '../averages/smma.js';
+import { UnequalArraySizesError } from '../errors/UnequalArraySizesError.js';
 import { type HighLowClose, type NonEmptyHighLowClose } from '../types.js';
 import * as array from '../utils/array.js';
 import * as number_ from '../utils/number.js';
@@ -29,14 +37,20 @@ const directionalMovement = (
 	F.pipe(
 		values.low,
 		array.tail,
-		E.map(
-			RNEA.mapWithIndex((index, low) => {
-				const previous = index;
-				const current = index + 1;
-				const up = values.high[current].sub(values.high[previous]);
-				const down = values.low[previous].sub(low);
-				return movement(up, down, move);
-			}),
+		E.chain(
+			RNEA.traverseWithIndex(E.Applicative)((index, low) =>
+				F.pipe(
+					O.bindTo('currentHigh')(RA.lookup(index + 1)(values.high)),
+					O.bind('previousHigh', () => RA.lookup(index)(values.high)),
+					O.bind('previousLow', () => RA.lookup(index)(values.low)),
+					O.map(({ currentHigh, previousHigh, previousLow }) => {
+						const up = currentHigh.sub(previousHigh);
+						const down = previousLow.sub(low);
+						return movement(up, down, move);
+					}),
+					E.fromOption(() => new UnequalArraySizesError()),
+				),
+			),
 		),
 	);
 
@@ -49,13 +63,19 @@ const directionalIndex = (
 		E.bindTo('dm')(directionalMovement(values, move)),
 		E.bind('dividends', ({ dm }) => smmaC(dm, period)),
 		E.bind('divisors', () => atrC(values, period)),
-		E.map(({ dividends, divisors }) =>
+		E.chain(({ dividends, divisors }) =>
 			F.pipe(
 				dividends,
-				RNEA.mapWithIndex((index, dividend) => {
-					const divisor = divisors[index];
-					return divisor.eq(0) ? new Big(0) : dividend.mul(100).div(divisor);
-				}),
+				RNEA.traverseWithIndex(E.Applicative)((index, dividend) =>
+					F.pipe(
+						RA.lookup(index)(divisors),
+						// v8 ignore next -- reaching this requires directionalMovement to have already succeeded, which guarantees divisors is at least as long as dividends
+						E.fromOption(() => new UnequalArraySizesError()),
+						E.map((divisor) =>
+							divisor.eq(0) ? new Big(0) : dividend.mul(100).div(divisor),
+						),
+					),
+				),
 			),
 		),
 	);
@@ -63,14 +83,21 @@ const directionalIndex = (
 const calculation = (
 	pdi: RNEA.ReadonlyNonEmptyArray<Big>,
 	mdi: RNEA.ReadonlyNonEmptyArray<Big>,
-): RNEA.ReadonlyNonEmptyArray<Big> =>
+): E.Either<Error, RNEA.ReadonlyNonEmptyArray<Big>> =>
 	F.pipe(
 		pdi,
-		RNEA.mapWithIndex((index, plus) => {
-			const sum = plus.add(mdi[index]);
-			const dividend = plus.sub(mdi[index]).abs();
-			return sum.eq(0) ? new Big(0) : dividend.div(sum);
-		}),
+		RNEA.traverseWithIndex(E.Applicative)((index, plus) =>
+			F.pipe(
+				RA.lookup(index)(mdi),
+				// v8 ignore next -- pdi and mdi come from the same directionalIndex call shape, so their lengths always match
+				E.fromOption(() => new UnequalArraySizesError()),
+				E.map((minus) => {
+					const sum = plus.add(minus);
+					const dividend = plus.sub(minus).abs();
+					return sum.eq(0) ? new Big(0) : dividend.div(sum);
+				}),
+			),
+		),
 	);
 
 /**
@@ -89,10 +116,12 @@ export const adx = (values: HighLowClose<number>, period = 14): E.Either<Error, 
 		E.bind('valuesB', ({ valuesV }) => rec.toBig(valuesV)),
 		E.bind('pdi', ({ periodV, valuesB }) => directionalIndex(valuesB, periodV, 'up')),
 		E.bind('mdi', ({ periodV, valuesB }) => directionalIndex(valuesB, periodV, 'down')),
-		E.bind('smoothed', ({ mdi, pdi, periodV }) => {
-			const calculated = calculation(pdi, mdi);
-			return smmaC(calculated, periodV);
-		}),
+		E.bind('smoothed', ({ mdi, pdi, periodV }) =>
+			F.pipe(
+				calculation(pdi, mdi),
+				E.chain((calculated) => smmaC(calculated, periodV)),
+			),
+		),
 		E.map(({ mdi, pdi, smoothed }) => ({
 			adx: F.pipe(
 				smoothed,

--- a/tests/config/setup.ts
+++ b/tests/config/setup.ts
@@ -1,4 +1,10 @@
-import { either as E, function as F, readonlyArray as RA, readonlyRecord as RR } from 'fp-ts';
+import {
+	either as E,
+	function as F,
+	option as O,
+	readonlyArray as RA,
+	readonlyRecord as RR,
+} from 'fp-ts';
 import { expect } from 'vitest';
 
 import {
@@ -44,7 +50,15 @@ const areResultRecordsEqual = (
 	decimals: number,
 ): boolean =>
 	areArraysEqual(Object.keys(exp), Object.keys(rec)) &&
-	Object.keys(exp).every((k) => areResultArraysEqual(exp[k], rec[k], decimals));
+	Object.keys(exp).every((k) =>
+		F.pipe(
+			O.bindTo('expValue')(RR.lookup(k)(exp)),
+			O.bind('recValue', () => RR.lookup(k)(rec)),
+			O.exists(({ expValue, recValue }) =>
+				areResultArraysEqual(expValue, recValue, decimals),
+			),
+		),
+	);
 
 expect.extend({
 	// vitest's `expect.extend` matcher API binds `this` to the matcher context

--- a/tests/movements/adx.spec.ts
+++ b/tests/movements/adx.spec.ts
@@ -32,6 +32,12 @@ describe('adx', () => {
 		).toStrictEqual(E.left(new UnequalArraySizesError()));
 	});
 
+	it('fails if high has fewer values than low', () => {
+		expect(adx({ close: [1, 2], high: [1, 2], low: [1, 2, 3] }, 1)).toStrictEqual(
+			E.left(new UnequalArraySizesError()),
+		);
+	});
+
 	it.each([
 		{ v: { close: [0, 0, 0, 0, 0], high: [0, 0, NaN, 0, 0], low: [0, 0, 0, 0, 0] } },
 		{

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
 	"extends": [
 		"@tsconfig/recommended/tsconfig.json",
 		"@tsconfig/node-lts/tsconfig.json",
-		"@tsconfig/node-ts/tsconfig.json"
+		"@tsconfig/node-ts/tsconfig.json",
+		"@tsconfig/strictest/tsconfig.json"
 	],
 	"compilerOptions": {
 		"outDir": "dist",


### PR DESCRIPTION
## Summary
- Extend `tsconfig.build.json` with [`@tsconfig/strictest`](https://www.npmjs.com/package/@tsconfig/strictest) to tighten the compiler settings (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitOverride`, `noImplicitReturns`, `noPropertyAccessFromIndexSignature`, ...)
- Replace manual offset-based array indexing in `dema`/`tema`/`macd`/`adx` with `RA.lookup` + `Option`, mirroring the `UnequalArraySizesError` pattern already used by `atr.ts`'s `trueRange`, so array access is exhaustively checked by the type system instead of silently assumed
- Fix the same class of unchecked index access in the test helper (`tests/config/setup.ts`)
- Mark the handful of resulting error branches that are unreachable by construction (array lengths are tied together by the EMA/SMMA math) with `v8 ignore next` plus a short rationale, to keep the existing 100% coverage threshold intact

## Why
`noUncheckedIndexedAccess` catches a real class of bugs (out-of-bounds array access silently returning `undefined`). This repo's own `no-non-null-assertion` / `no-throw-statements` lint rules rule out the usual quick fixes, so the fallout was resolved properly by removing manual index arithmetic in favor of total, `Option`-based lookups.

As a side effect, `adx()` now returns a clean `Left(UnequalArraySizesError)` when `high` is shorter than `low`, instead of throwing a raw `TypeError` — covered by a new test in `adx.spec.ts`.

## Changes
- `tsconfig.build.json`: add `@tsconfig/strictest` to `extends`
- `package.json` / `pnpm-lock.yaml`: add `@tsconfig/strictest` devDependency
- `src/averages/{dema,tema,macd}.ts`: `calculate()` rewritten with `RNEA.traverseWithIndex` + `RA.lookup` instead of direct offset indexing
- `src/movements/adx.ts`: `directionalMovement`, `directionalIndex`, `calculation` rewritten the same way
- `tests/movements/adx.spec.ts`: new test for `high` shorter than `low`
- `tests/config/setup.ts`: `areResultRecordsEqual` rewritten with `RR.lookup` + `Option` instead of unchecked record indexing

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test` (168 tests, 100% coverage)
